### PR TITLE
Add Support for PHB1 and PHB2 Class Powers (Default/AEDU Classes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ source, and class type (default, essentials, and hybrid). Added choices for Aven
 v.0.5.0 - 11/16/2025 - Tested and fixed issues for class features up to the end of PHB2 (Avenger, Barbarian, Bard, Druid, Invoker, Shaman, Sorcerer, and Warden).\
 v.0.6.0 - 11/25/2025 - There is now a UI to add your own custom classes, although automation for them isn't set up (will do this after finishing automation for all the compendium classes). Added filters for the power library for class, keywords, level, publishing source, recharge, and type. Tested and fixed issues for class features for HotFL and HotFK Essentials classes (Druid (Sentinel), Paladin (Cavalier), Ranger (Hunter), Ranger (Scout), Warlock (Hexblade), Cleric (Warpriest), Fighter (Knight), Fighter (Slayer), and Rogue (Thief))
 v.0.7.0 - 12/1/2025 - Finished adding the rest of the Essentials classes by testing and fixing class features for HoEC and NCS classes (Wizard (Bladesinger), Sorcerer (Elementalist), Wizard (Sha'ir)). Also added links to the selection dialogues.
+v.0.8.0 - 12/5/2025 - Added support for class powers for standard AEDU classes. Completed testing and support for class powers for PHB1 and PHB2 classes.
 
 
 
@@ -33,6 +34,7 @@ What This Extension Does:
 * It adds bonus to defenses (as of v.0.2.0)
 * It adds class features (as of v.0.2.0)
 * It has a UI to add your own custom classes (as of v.0.6.0)
+* It adds powers now (as of v.0.8.0)
 
 
 
@@ -43,7 +45,6 @@ What This Extension Does Not Do (but it might do one day):
 
 
 * It does not allow class support beyond first level.
-* It does not add powers yet.
 * It doesn't support hybrid classes.
 * It only supports base classes, not paragon classes or epic destinies.
 

--- a/extension.xml
+++ b/extension.xml
@@ -16,7 +16,7 @@
 
 	<base>
 		<!-- Library Data -->
-		<script name="4eClassesExtensionLibraryData" file="scripts/data_library_4e_class.lua" />
+		<script name="Classes4eExtensionLibraryData" file="scripts/data_library_4e_class.lua" />
 
 		<!-- Campaign -->
 		<includefile source="campaign/record_char_main.xml" />

--- a/extension.xml
+++ b/extension.xml
@@ -4,7 +4,7 @@
 	<announcement text="DnD 4e Classes extension made by SieferSeesSomething is activated. Last release 12/01/2025" font="emotefont" icon="rulesetlogo_CoreRPG"/>
 	<properties>
 		<name>DnD 4e - Character Classes Extension</name>
-		<version>0.7.0</version>
+		<version>0.8.0</version>
 		<author>Jason Williams</author>
 		<description>
 		Adds a character options menu for classes and a link to the character sheet.

--- a/extension.xml
+++ b/extension.xml
@@ -29,6 +29,7 @@
 		<script name="CharClassBuildDropManager" file="scripts/manager_char_build_drop_4e.lua" />
 		<script name="CharClassManager" file="scripts/manager_char_class_4e.lua" />
 		<script name="CharClassFeatureManager" file="scripts/manager_char_class_features.lua" />
+		<script name="CharClassPowerManager" file="scripts/manager_char_class_powers.lua" />
 		<!-- <script name="RaceManager" file="scripts/manager_race_4e.lua" /> -->
 
 		<!-- String resources -->

--- a/scripts/manager_char_class_4e.lua
+++ b/scripts/manager_char_class_4e.lua
@@ -28,8 +28,8 @@ function addClass(nodeChar, sRecord, tData)
 	--Add Class Features
 	addClassFeatures(rAdd, sRecord, sDescriptionText, sClassName);
 
-	-- --Add Race Powers
-	-- addRacePowers(rAdd, sRecord, sDescriptionText);
+	-- --Add Class Powers
+	addClassPowers(rAdd, sRecord, sDescriptionText, sClassName);
 
 	-- --Add skill bonuses
 	addClassSkill(rAdd, sRecord, sDescriptionText);
@@ -326,79 +326,196 @@ function cutoffLastClassFeatureDescription(sDescriptionText, sClassFeatureSpecif
 	return sClassFeatureSpecificDescriptionText, sClassFeatureDescriptionPattern;
 end
 
-function addRacePowers(rAdd, sRecord, sDescriptionText)
+function addClassPowers(rAdd, sRecord, sDescriptionText, sClassName)
 	local tCurrentPowers = DB.getChildren(rAdd.nodeChar, "powers");
 	--first try through the newly added powers node
-	local sRecordPowerNode = DB.findNode(DB.getPath(sRecord, "powers"));
-	if sRecordPowerNode then
-		local nodePowerChildren = DB.getChildren(sRecordPowerNode);
-		for nodeName,nodeChild in pairs(nodePowerChildren) do
-			local sRacialPowerName = DB.getText(DB.getPath(nodeChild, "name"));
-			local isPowerInList = false;
-			for _, powerNode in pairs(tCurrentPowers) do
-				if DB.getText(powerNode, "name") == DB.getText(nodeChild, "name") then
-					isPowerInList = true;
-					break;
-				end
-			end
-			if isPowerInList == false then
-				local sRacialActionSpeed = DB.getText(DB.getPath(nodeChild, "action"));
-				local sRacialSource = DB.getText(DB.getPath(nodeChild, "source"));
-				local sRacialKeywords = DB.getText(DB.getPath(nodeChild, "keywords"));
-				local sRacialRange = DB.getText(DB.getPath(nodeChild, "range"));
-				local sRacialRecharge = DB.getText(DB.getPath(nodeChild, "recharge"));
-				local sRacialFlavor = DB.getText(DB.getPath(nodeChild, "flavor"));
-				if sRacialFlavor == nil then
-					sRacialFlavor = "";
-				end
-				local sRacialFullDescription = sRacialFlavor .. "\n\n" .. DB.getText(DB.getPath(nodeChild, "shortdescription"));
-				local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("powers"));
-				DB.setValue(rCreatedIDChildNode, "action", "string", sRacialActionSpeed);
-				DB.setValue(rCreatedIDChildNode, "name", "string", sRacialPowerName);
-				DB.setValue(rCreatedIDChildNode, "source", "string", sRacialSource);
-				DB.setValue(rCreatedIDChildNode, "keywords", "string", sRacialKeywords);
-				DB.setValue(rCreatedIDChildNode, "range", "string", sRacialRange);
-				DB.setValue(rCreatedIDChildNode, "recharge", "string", sRacialRecharge);
-				DB.setValue(rCreatedIDChildNode, "shortdescription", "string", sRacialFullDescription);
-				CharManager.parseDescription(rCreatedIDChildNode);
-				ChatManager.SystemMessageResource("char_abilities_message_poweradd", sRacialPowerName, rAdd.sCharName);
-			end
-		end
-	elseif sDescriptionText then --then try through the description text
+	-- local sRecordPowerNode = DB.findNode(DB.getPath(sRecord, "powers"));
+	-- if sRecordPowerNode then
+	-- 	local nodePowerChildren = DB.getChildren(sRecordPowerNode);
+	-- 	for nodeName,nodeChild in pairs(nodePowerChildren) do
+	-- 		local sRacialPowerName = DB.getText(DB.getPath(nodeChild, "name"));
+	-- 		local isPowerInList = false;
+	-- 		for _, powerNode in pairs(tCurrentPowers) do
+	-- 			if DB.getText(powerNode, "name") == DB.getText(nodeChild, "name") then
+	-- 				isPowerInList = true;
+	-- 				break;
+	-- 			end
+	-- 		end
+	-- 		if isPowerInList == false then
+	-- 			local sRacialActionSpeed = DB.getText(DB.getPath(nodeChild, "action"));
+	-- 			local sRacialSource = DB.getText(DB.getPath(nodeChild, "source"));
+	-- 			local sRacialKeywords = DB.getText(DB.getPath(nodeChild, "keywords"));
+	-- 			local sRacialRange = DB.getText(DB.getPath(nodeChild, "range"));
+	-- 			local sRacialRecharge = DB.getText(DB.getPath(nodeChild, "recharge"));
+	-- 			local sRacialFlavor = DB.getText(DB.getPath(nodeChild, "flavor"));
+	-- 			if sRacialFlavor == nil then
+	-- 				sRacialFlavor = "";
+	-- 			end
+	-- 			local sRacialFullDescription = sRacialFlavor .. "\n\n" .. DB.getText(DB.getPath(nodeChild, "shortdescription"));
+	-- 			local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("powers"));
+	-- 			DB.setValue(rCreatedIDChildNode, "action", "string", sRacialActionSpeed);
+	-- 			DB.setValue(rCreatedIDChildNode, "name", "string", sRacialPowerName);
+	-- 			DB.setValue(rCreatedIDChildNode, "source", "string", sRacialSource);
+	-- 			DB.setValue(rCreatedIDChildNode, "keywords", "string", sRacialKeywords);
+	-- 			DB.setValue(rCreatedIDChildNode, "range", "string", sRacialRange);
+	-- 			DB.setValue(rCreatedIDChildNode, "recharge", "string", sRacialRecharge);
+	-- 			DB.setValue(rCreatedIDChildNode, "shortdescription", "string", sRacialFullDescription);
+	-- 			CharManager.parseDescription(rCreatedIDChildNode);
+	-- 			ChatManager.SystemMessageResource("char_abilities_message_poweradd", sRacialPowerName, rAdd.sCharName);
+	-- 		end
+	-- 	end
+	-- else
+	if sDescriptionText then --then try through the description text
 		local referenceStaticNode = DB.findNode("reference.powers.");
 		local powersNode = DB.getChild(referenceStaticNode, "powers");
 		local sPowersPattern = '<link class="powerdesc" recordname="reference.powers.(%w+)@([%w%s]+)">';
-		local sPowersLink = string.gmatch(sDescriptionText, sPowersPattern);
-		for w,v in sPowersLink do
-			local sPowersPattern = "reference.powers." .. w .. "@" .. v;
-			local sRacialPowerName = DB.getText(DB.getPath(sPowersPattern, "name"));
-			local isPowerInList = false;
-			for _, powerNode in pairs(tCurrentPowers) do
-				if DB.getText(powerNode, "name") == sRacialPowerName then
-					isPowerInList = true;
-					break;
+		local sFirstPowersLinkMatch, sFirstPowersLinkModuleMatch = string.match(sDescriptionText, sPowersPattern);
+		if not isEssentialsClass(sClassName) then
+			local tRefreshTypes = { "At-Will", "Encounter", "Daily" };
+			for i,refresh in ipairs(tRefreshTypes) do
+				local tPowersforLevelAndClass = {};
+				local tPowers = {};
+				local nPowersCount = 1;
+				local nOptionsCount = 1;
+				local tPowerNodes = DB.getChildrenGlobal("reference.powers");
+				for _,powerNode in ipairs(tPowerNodes) do
+					local sPowerClass = Classes4eExtensionLibraryData.getClassOrRaceValue(powerNode);
+					local sPowerLevel = Classes4eExtensionLibraryData.getPowerLevelValue(powerNode);
+					local sPowerRecharge = Classes4eExtensionLibraryData.getRechargeValue(powerNode);
+					if sPowerClass == sClassName and sPowerLevel == "1" then
+						tPowersforLevelAndClass[nOptionsCount] = powerNode;
+						nOptionsCount = nOptionsCount + 1;
+						if sPowerRecharge == refresh then
+							tPowers[nPowersCount] = powerNode;
+							nPowersCount = nPowersCount + 1;
+						end
+					end
 				end
-			end
-			if isPowerInList == false then
-				local sRacialActionSpeed = DB.getText(DB.getPath(sPowersPattern, "action"));
-				local sRacialSource = DB.getText(DB.getPath(sPowersPattern, "source"));
-				local sRacialKeywords = DB.getText(DB.getPath(sPowersPattern, "keywords"));
-				local sRacialRange = DB.getText(DB.getPath(sPowersPattern, "range"));
-				local sRacialRecharge = DB.getText(DB.getPath(sPowersPattern, "recharge"));
-				local sRacialFullDescription = DB.getText(DB.getPath(sPowersPattern, "flavor")) .. "\n\n" .. DB.getText(DB.getPath(sPowersPattern, "description"))
-				local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("powers"));
-				DB.setValue(rCreatedIDChildNode, "action", "string", sRacialActionSpeed);
-				DB.setValue(rCreatedIDChildNode, "name", "string", sRacialPowerName);
-				DB.setValue(rCreatedIDChildNode, "source", "string", sRacialSource);
-				DB.setValue(rCreatedIDChildNode, "keywords", "string", sRacialKeywords);
-				DB.setValue(rCreatedIDChildNode, "range", "string", sRacialRange);
-				DB.setValue(rCreatedIDChildNode, "recharge", "string", sRacialRecharge);
-				DB.setValue(rCreatedIDChildNode, "shortdescription", "string", sRacialFullDescription);
-				CharManager.parseDescription(rCreatedIDChildNode);
-				ChatManager.SystemMessageResource("char_abilities_message_poweradd", sRacialPowerName, rAdd.sCharName);
+				local nNumberOfPowers = 1;
+				if refresh == "At-Will" then
+					nNumberOfPowers = 2;
+				end
+				addStandardPowers(rAdd, sRecord, sDescriptionText, sClassName, tPowers, nNumberOfPowers, refresh);
 			end
 		end
+
+		-- local sPowersLink = string.gmatch(sDescriptionText, sPowersPattern);
+		-- for w,v in sPowersLink do
+		-- 	local sPowersPattern = "reference.powers." .. w .. "@" .. v;
+		-- 	local sRacialPowerName = DB.getText(DB.getPath(sPowersPattern, "name"));
+		-- 	local isPowerInList = false;
+		-- 	for _, powerNode in pairs(tCurrentPowers) do
+		-- 		if DB.getText(powerNode, "name") == sRacialPowerName then
+		-- 			isPowerInList = true;
+		-- 			break;
+		-- 		end
+		-- 	end
+		-- 	if isPowerInList == false then
+		-- 		local sRacialActionSpeed = DB.getText(DB.getPath(sPowersPattern, "action"));
+		-- 		local sRacialSource = DB.getText(DB.getPath(sPowersPattern, "source"));
+		-- 		local sRacialKeywords = DB.getText(DB.getPath(sPowersPattern, "keywords"));
+		-- 		local sRacialRange = DB.getText(DB.getPath(sPowersPattern, "range"));
+		-- 		local sRacialRecharge = DB.getText(DB.getPath(sPowersPattern, "recharge"));
+		-- 		local sRacialFullDescription = DB.getText(DB.getPath(sPowersPattern, "flavor")) .. "\n\n" .. DB.getText(DB.getPath(sPowersPattern, "description"))
+		-- 		local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("powers"));
+		-- 		DB.setValue(rCreatedIDChildNode, "action", "string", sRacialActionSpeed);
+		-- 		DB.setValue(rCreatedIDChildNode, "name", "string", sRacialPowerName);
+		-- 		DB.setValue(rCreatedIDChildNode, "source", "string", sRacialSource);
+		-- 		DB.setValue(rCreatedIDChildNode, "keywords", "string", sRacialKeywords);
+		-- 		DB.setValue(rCreatedIDChildNode, "range", "string", sRacialRange);
+		-- 		DB.setValue(rCreatedIDChildNode, "recharge", "string", sRacialRecharge);
+		-- 		DB.setValue(rCreatedIDChildNode, "shortdescription", "string", sRacialFullDescription);
+		-- 		CharManager.parseDescription(rCreatedIDChildNode);
+		-- 		ChatManager.SystemMessageResource("char_abilities_message_poweradd", sRacialPowerName, rAdd.sCharName);
+		-- 	end
+		-- end
+	end 
+end
+function addStandardPowers(rAdd, sRecord, sDescriptionText, sClassName, tPowers, nNumberOfPowers, sRefreshText)
+	local tOptions = {};
+	local nOptionsCount = 1;
+	for _,y in ipairs(tPowers) do
+		local sClassFeatureName = DB.getText(DB.getPath(y, "name"));
+		local sClassFeatureDescription = DB.getText(DB.getPath(y, "description"));
+		table.insert(tOptions, { text = sClassFeatureName, linkclass = "powerdesc", linkrecord = DB.getPath(y), });
+		nOptionsCount = nOptionsCount + 1;
 	end
+	if not nNumberOfPowers then
+		nNumberOfPowers = 1;
+	end
+	local tDialogData = {
+		title = sRefreshText .. " Power Selection",
+		msg = "Choose an " .. sRefreshText .. " power",
+		options = tOptions,
+		min = nNumberOfPowers,
+		max = nNumberOfPowers,
+		callback = CharClassManager.callbackResolveClassPowerSelectionsDialogSelection,
+		custom = rAdd, 
+	};
+	DialogManager.requestSelectionDialog(tDialogData);	
+end
+function callbackResolveClassPowerSelectionsDialogSelection(tSelection, rAdd, tSelectionLinks)
+	if not tSelection or not tSelection[1] then
+		CharManager.outputUserMessage("char_error_addclasssfeature");
+		return;
+	end
+	if not tSelectionLinks then
+		CharManager.outputUserMessage("char_error_addclasssfeature");
+		return;
+	end
+	for i, selectedPower in ipairs(tSelectionLinks) do
+		local sPowerPath = selectedPower.linkrecord;
+		local sPowerName = tSelection[i];
+		Debug.console("sPowerName", sPowerName);
+
+		local tCurrentPowers = DB.getChildren(rAdd.nodeChar, "powers");
+		local isPowerInList = false;
+		for _, powerNode in pairs(tCurrentPowers) do
+			if DB.getText(powerNode, "name") == sPowerName then
+				isPowerInList = true;
+				break;
+			end
+		end
+		if isPowerInList == false then
+			local sPowerActionSpeed = DB.getText(DB.getPath(sPowerPath, "action"));
+			local sPowerSource = DB.getText(DB.getPath(sPowerPath, "source"));
+			local sPowerKeywords = DB.getText(DB.getPath(sPowerPath, "keywords"));
+			local sPowerRange = DB.getText(DB.getPath(sPowerPath, "range"));
+			local sPowerRecharge = DB.getText(DB.getPath(sPowerPath, "recharge"));
+			local sPowerFullDescription = DB.getText(DB.getPath(sPowerPath, "flavor")) .. "\n\n" .. DB.getText(DB.getPath(sPowerPath, "description"))
+			local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("powers"));
+			DB.setValue(rCreatedIDChildNode, "action", "string", sPowerActionSpeed);
+			DB.setValue(rCreatedIDChildNode, "name", "string", sPowerName);
+			DB.setValue(rCreatedIDChildNode, "source", "string", sPowerSource);
+			DB.setValue(rCreatedIDChildNode, "keywords", "string", sPowerKeywords);
+			DB.setValue(rCreatedIDChildNode, "range", "string", sPowerRange);
+			DB.setValue(rCreatedIDChildNode, "recharge", "string", sPowerRecharge);
+			DB.setValue(rCreatedIDChildNode, "shortdescription", "string", sPowerFullDescription);
+			CharManager.parseDescription(rCreatedIDChildNode);
+			ChatManager.SystemMessageResource("char_abilities_message_poweradd", sPowerName, rAdd.sCharName);
+		end
+	end
+
+	-- local sSelectedClassFeatureSelectionsDBReference;
+	-- local tCurrentFeatures = DB.getChildren(tData.rAdd.nodeChar, "specialabilitylist");
+	-- for _,selectedPower in ipairs(tSelection) do
+	-- 	for _, featureNode in pairs(tCurrentFeatures) do
+	-- 		if DB.getText(DB.getPath(featureNode, "value")) ~= selectedPower then
+	-- 			for x, y in pairs(tData.tClassFeatureOptions) do
+	-- 				if DB.getText(DB.getPath(featureNode, "value")) == x then
+	-- 					DB.deleteNode(featureNode);
+	-- 					break;
+	-- 				end
+	-- 			end
+	-- 		end
+	-- 	end
+	-- 	sSelectedClassFeatureSelectionsDBReference = tSelection[selectedPower];
+	-- 	local rCreatedIDChildNode = DB.createChild(tData.rAdd.nodeChar.getPath("specialabilitylist"));
+	-- 	DB.setValue(rCreatedIDChildNode, "shortcut", "windowreference", "powerdesc", sSelectedClassFeatureSelectionsDBReference);
+	-- 	DB.setValue(rCreatedIDChildNode, "value", "string", selectedSkill);
+	-- 	--DB.setValue(rCreatedIDChildNode, "description", "string", sClassFeatureOriginalDescription);
+	-- 	ChatManager.SystemMessageResource("char_abilities_message_classfeatureadd", selectedSkill, tData.rAdd.sCharName);
+	-- end
 end
 
 function addClassSkill(rAdd, sRecord, sDescriptionText)
@@ -637,6 +754,35 @@ function removeLinkLists(sText)
 	sText = string.gsub(sText, "<link.->", "\n - ");
 	sText = string.gsub(sText, "</link>", "\n");	
 	return sText;
+end
+
+-----------------------------------------------------------
+
+function isEssentialsClass(sClassName)
+	local tEssentialsClasses = {};
+	tEssentialsClasses["BARBARIAN (BERSERKER)"] = true;
+	tEssentialsClasses["WARLOCK (BINDER)"] = true;
+	tEssentialsClasses["PALADIN (BLACKGUARD)"] = true;
+	tEssentialsClasses["WIZARD (BLADESINGER)"] = true;
+	tEssentialsClasses["PALADIN (CAVALIER)"] = true;
+	tEssentialsClasses["SORCERER (ELEMENTALIST)"] = true;
+	tEssentialsClasses["ASSASSIN (EXECUTIONER)"] = true;
+	tEssentialsClasses["RANGER (HUNTER)"] = true;
+	tEssentialsClasses["WARLOCK (HEXBLADE)"] = true;
+	tEssentialsClasses["FIGHTER (KNIGHT)"] = true;
+	tEssentialsClasses["WIZARD (MAGE)"]	= true;	
+	tEssentialsClasses["DRUID (PROTECTOR)"] = true;
+	tEssentialsClasses["ROGUE (THIEF)"] = true;
+	tEssentialsClasses["RANGER (SCOUT)"] = true;
+	tEssentialsClasses["DRUID (SENTINEL)"] = true;
+	tEssentialsClasses["WIZARD (SHA'IR)"] = true;
+	tEssentialsClasses["BARD (SKALD)"] = true;
+	tEssentialsClasses["FIGHTER (SLAYER)"] = true;
+	tEssentialsClasses["VAMPIRE"] = true;	
+	tEssentialsClasses["CLERIC (WARPRIEST)"] = true;
+	tEssentialsClasses["WIZARD (WITCH)"] = true;
+
+	return tEssentialsClasses[sClassName:upper()];
 end
 
 -----------------------------------------------------------

--- a/scripts/manager_char_class_4e.lua
+++ b/scripts/manager_char_class_4e.lua
@@ -274,6 +274,11 @@ function addClassFeatures(rAdd, sRecord, sDescriptionText, sClassName)
 				end
 				if isFeatureInList == false then
 					CharClassFeatureManager.addClassSpecificFeatures(sClassName, rAdd, v, sClassFeatureFilteredDescriptionText, sClassFeatureSpecificDescriptionText);
+					if not string.find(sClassFeatureSpecificDescriptionText:lower(), "choose") 
+						and not string.find(sClassFeatureSpecificDescriptionText:lower(), "choice")
+						and not string.find(sClassFeatureSpecificDescriptionText:lower(), "following") then
+							CharClassPowerManager.addAllFeaturePowers(rAdd, sClassFeatureSpecificDescriptionText, sClassName);
+					end
 				end
 			end
 		end
@@ -377,12 +382,14 @@ function addClassPowers(rAdd, sRecord, sDescriptionText, sClassName)
 				local tPowers = {};
 				local nPowersCount = 1;
 				local nOptionsCount = 1;
+				--Use version of class name without the parentheses
+				local sFilteredClassName = StringManager.trim(string.gsub(sClassName, "%b()", ""));
 				local tPowerNodes = DB.getChildrenGlobal("reference.powers");
 				for _,powerNode in ipairs(tPowerNodes) do
 					local sPowerClass = Classes4eExtensionLibraryData.getClassOrRaceValue(powerNode);
 					local sPowerLevel = Classes4eExtensionLibraryData.getPowerLevelValue(powerNode);
 					local sPowerRecharge = Classes4eExtensionLibraryData.getRechargeValue(powerNode);
-					if sPowerClass == sClassName and sPowerLevel == "1" then
+					if sPowerClass == sFilteredClassName and sPowerLevel == "1" then
 						tPowersforLevelAndClass[nOptionsCount] = powerNode;
 						nOptionsCount = nOptionsCount + 1;
 						if sPowerRecharge == refresh then
@@ -391,11 +398,12 @@ function addClassPowers(rAdd, sRecord, sDescriptionText, sClassName)
 						end
 					end
 				end
+				--Standard characters start with 2 At-Will powers, 1 encounter, and 1 daily from their class
 				local nNumberOfPowers = 1;
 				if refresh == "At-Will" then
 					nNumberOfPowers = 2;
 				end
-				addStandardPowers(rAdd, sRecord, sDescriptionText, sClassName, tPowers, nNumberOfPowers, refresh);
+				addStandardPowers(rAdd, sRecord, sDescriptionText, sFilteredClassName, tPowers, nNumberOfPowers, refresh);
 			end
 		end
 

--- a/scripts/manager_char_class_features.lua
+++ b/scripts/manager_char_class_features.lua
@@ -126,7 +126,7 @@ function displayAlternativeFeatureDialog(rAdd, tAlternativeClassFeatures, tStrin
 end
 function callbackResolveAlternativeFeatureDialogSelection(tSelection, tData)
 	if not tSelection or not tSelection[1]  then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	local tCurrentFeatures = DB.getChildren(tData.rAdd.nodeChar, "specialabilitylist");
@@ -182,7 +182,7 @@ function displayClassFeatureSelectionsDialog(rAdd, sClassFeatureOriginalDescript
 end
 function callbackResolveClassFeatureSelectionsDialogSelection(tSelection, tData)
 	if not tSelection or not tSelection[1] then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	local sSelectedClassFeatureSelectionsDBReference;
@@ -313,11 +313,11 @@ function displayClericTemplarHealerLoreDialog(rAdd, sbattleClericLoreReference)
 end
 function callbackResolveClericHealerLoreDialogSelection(tSelection, rAdd, tSelectionLinks)
 	if not tSelectionLinks then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	if not tSelection then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	local tCurrentFeatures = DB.getChildren(rAdd.nodeChar, "specialabilitylist");
@@ -409,11 +409,11 @@ function displayClericTemplarChannelDivinityDialog(rAdd)
 end
 function callbackResolveClericChannelDivinity(tSelection, rAdd, tSelectionLinks)
 	if not tSelectionLinks then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	if not tSelection then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	local tCurrentFeatures = DB.getChildren(rAdd.nodeChar, "specialabilitylist");
@@ -577,7 +577,7 @@ function displayRangerPrimeShotDialog(rAdd, sClassFeatureOriginalDescription)
 end
 function callbackResolveRangerPrimeShotDialogSelection(tSelection, rAdd)
 	if not tSelection or not tSelection[1] then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	local tCurrentFeatures = DB.getChildren(rAdd.nodeChar, "specialabilitylist");
@@ -643,7 +643,7 @@ function displayRangerFightingStyleDialog(rAdd, sClassFeatureOriginalDescription
 end
 function callbackResolveFightingStyleDialogSelection(tSelection, tData)
 	if not tSelection or not tSelection[1] then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	local sSelectedFightingStyleDBReference;
@@ -873,7 +873,7 @@ function displayWarlordMarshalArcherWarlordDialog(rAdd)
 end
 function callbackResolveWarlordMarshalArcherWarlordDialogSelection(tSelection, rAdd)
 	if not tSelection or not tSelection[1] then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	local tCurrentFeatures = DB.getChildren(rAdd.nodeChar, "specialabilitylist");
@@ -935,6 +935,15 @@ function addWizardArcanistFeatures(sClassName, rAdd, sClassFeatureName, sClassFe
 		DB.setValue(rCreatedIDChildNode, "value", "string", sClassFeatureName);
 		DB.setValue(rCreatedIDChildNode, "description", "string", sClassFeatureFilteredDescription);
 		ChatManager.SystemMessageResource("char_abilities_message_classfeatureadd", sClassFeatureName, rAdd.sCharName);
+
+		--Add powers
+		if string.find(sClassFeatureName:lower(), "cantrips") then
+			CharClassPowerManager.dispayItalicPowersDialog(rAdd, sClassFeatureOriginalDescription, sClassFeatureName);
+		end
+		if string.find(sClassFeatureName:lower(), "spellbook") then
+			local nNumberOfPowersChoice = 2;
+			CharClassPowerManager.addWizardArcanistSpellbookPowers(rAdd, sClassName, nNumberOfPowersChoice);
+		end
 	end
 end
 
@@ -1027,7 +1036,9 @@ function addDruidFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilt
 		local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("specialabilitylist"));
 		DB.setValue(rCreatedIDChildNode, "shortcut", "windowreference");
 		DB.setValue(rCreatedIDChildNode, "value", "string", "Druids and Rituals");
-		DB.setValue(rCreatedIDChildNode, "description", "string", removeLinkLists(convertHTMLTable(sDruidsRitualsText)));	
+		DB.setValue(rCreatedIDChildNode, "description", "string", removeLinkLists(convertHTMLTable(sDruidsRitualsText)));
+
+		CharClassPowerManager.addAllFeaturePowers(rAdd, sClassFeatureOriginalDescription, sClassName);
 	else
 		local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("specialabilitylist"));
 		DB.setValue(rCreatedIDChildNode, "shortcut", "windowreference");
@@ -1049,7 +1060,7 @@ function addInvokerFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFi
 		DB.setValue(rCreatedIDChildNode, "shortcut", "windowreference");
 		DB.setValue(rCreatedIDChildNode, "value", "string", sClassFeatureName);
 		DB.setValue(rCreatedIDChildNode, "description", "string", sClassFeatureFilteredDescription);
-		displayClassFeatureSelectionsDialog(rAdd, sClassFeatureOriginalDescription, sClassFeatureName);
+		displayClassFeatureSelectionsDialog(rAdd, sClassFeatureOriginalDescription, sClassFeatureName, 1, 1);
 	else
 		local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("specialabilitylist"));
 		DB.setValue(rCreatedIDChildNode, "shortcut", "windowreference");
@@ -1149,7 +1160,7 @@ function displaySorcererSpellSourceDialog(rAdd, sClassFeatureOriginalDescription
 end
 function callbackResolveSorcererSpellSourceSelectionsDialogSelection(tSelection, tData)
 	if not tSelection or not tSelection[1] then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	local sSelectedClassFeatureSelectionsDBReference;
@@ -1456,11 +1467,11 @@ function displayArtificerHealingInfusionDialog(rAdd)
 end
 function callbackResolveArtificerHealingInfusion(tSelection, rAdd, tSelectionLinks)
 	if not tSelectionLinks then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	if not tSelection then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	local tCurrentFeatures = DB.getChildren(rAdd.nodeChar, "specialabilitylist");
@@ -1566,7 +1577,7 @@ function addClericWarpriestPreFeatures(sClassName, rAdd, sDescriptionText, tClas
 end
 function callbackResolveClericWarpriestPreFeatureSelection(tSelection, tData)
 	if not tSelection and #tSelection == 1 then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 
@@ -1676,7 +1687,7 @@ function displayClericWarpriestDomainDialog(sClassName, rAdd, sClassFeatureOrigi
 end
 function callbackResolveClericWarpriestDomainSelection(tSelection, tData)
 	if not tSelection and #tSelection == 1 then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	if #tSelection == 1 then
@@ -1790,7 +1801,7 @@ function displayFighterKnightFeywildGuardianDialog(rAdd, sClassFeatureOriginalDe
 end
 function callbackResolveFighterKnightBattleGuardianSelection(tSelection, tData)
 	if not tSelection and #tSelection == 1 then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	if #tSelection == 1 then
@@ -1875,7 +1886,7 @@ function addDruidSentinelPreFeatures(sClassName, rAdd, sDescriptionText, tClassF
 end
 function callbackResolveDruidSentinelPreFeatureSelection(tSelection, tData)
 	if not tSelection and #tSelection == 1 then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 
@@ -1985,7 +1996,7 @@ function displayDruidSentinelSeasonDialog(sClassName, rAdd, sClassFeatureOrigina
 end
 function callbackResolveDruidSentinelSeasonSelection(tSelection, tData)
 	if not tSelection and #tSelection == 1 then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	if #tSelection == 1 then
@@ -2178,7 +2189,7 @@ function addWarlockHexbladePreFeatures(sClassName, rAdd, sDescriptionText, tClas
 end
 function callbackResolveWarlockHexbladePreFeatureSelection(tSelection, tData)
 	if not tSelection and #tSelection == 1 then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 
@@ -2295,7 +2306,7 @@ function displayWarlockHexbladePactDialog(sClassName, rAdd, sClassFeatureOrigina
 end
 function callbackResolveWarlockHexbladePactSelection(tSelection, tData)
 	if not tSelection and #tSelection == 1 then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	if #tSelection == 1 then
@@ -2398,7 +2409,7 @@ function displayAssassinExecutionerGuildAttacksSelectionsDialog(rAdd, sClassFeat
 end
 function callbackResolveAssassinExecutionerGuildAttacksSelectionsDialogSelection(tSelection, tData)
 	if not tSelection or not tSelection[1] then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	local sSelectedClassFeatureSelectionsDBReference;
@@ -2649,7 +2660,7 @@ function addDruidProtectorPreFeatures(sClassName, rAdd, sDescriptionText, tClass
 end
 function callbackResolveDruidProtectorPreFeatureSelection(tSelection, tData)
 	if not tSelection and #tSelection == 1 then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 
@@ -2755,7 +2766,7 @@ function displayDruidProtectorCircleDialog(sClassName, rAdd, sClassFeatureOrigin
 end
 function callbackResolveDruidProtectorCircleSelection(tSelection, tData)
 	if not tSelection and #tSelection == 1 then
-		CharManager.outputUserMessage("char_error_addclasssfeature");
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	if #tSelection == 1 then
@@ -2928,3 +2939,4 @@ end
 function titleCase( first, rest )
    return first:upper()..rest:lower()
 end
+

--- a/scripts/manager_char_class_features.lua
+++ b/scripts/manager_char_class_features.lua
@@ -1081,7 +1081,7 @@ function addShamanFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFil
 		DB.setValue(rCreatedIDChildNode, "shortcut", "windowreference");
 		DB.setValue(rCreatedIDChildNode, "value", "string", sClassFeatureName);
 		DB.setValue(rCreatedIDChildNode, "description", "string", sClassFeatureFilteredDescription);
-		displayClassFeatureSelectionsDialog(rAdd, sClassFeatureOriginalDescription, sClassFeatureName);
+		displayClassFeatureSelectionsDialog(rAdd, sClassFeatureOriginalDescription, sClassFeatureName, 1, 1);
 	elseif sClassFeatureName == "Speak with Spirits" then
 		local speakWithSpiritsText = string.match(sClassFeatureOriginalDescription, "(.+)<p>Shaman Overview</p>")
 		local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("specialabilitylist"));

--- a/scripts/manager_char_class_powers.lua
+++ b/scripts/manager_char_class_powers.lua
@@ -1,0 +1,56 @@
+function addClassSpecificPowers(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription)
+	switch(sClassName:upper(), 
+	{
+		--PHB1
+		["CLERIC (TEMPLAR)"] = function() return addClericTemplarFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["FIGHTER (WEAPONMASTER)"] = function() return addFighterWeaponmasterFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["RANGER"] = function() return addRangerFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["ROGUE (SCOUNDREL)"] = function() return addRogueScoundrelFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["WARLOCK"] = function() return addWarlockFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["WARLORD (MARSHAL)"] = function() return addWarlordMarshalFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["WIZARD (ARCANIST)"] = function() return addWizardArcanistFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		--PHB2
+		["AVENGER"] = function() return addAvengerFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["BARBARIAN"] = function() return addBarbarianFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["BARD"] = function() return addBardFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["DRUID"] = function() return addDruidFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["INVOKER"] = function() return addInvokerFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["SHAMAN"] = function() return addShamanFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["SORCERER"] = function() return addSorcererFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["WARDEN"] = function() return addWardenFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		--PHB3
+		["ARDENT"] = function() return addArdentFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["BATTLEMIND"] = function() return addBattlemindFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["MONK"] = function() return addMonkFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,	
+		["PSION"] = function() return addPsionFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["RUNEPRIEST"] = function() return addRunepriestFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["SEEKER"] = function() return addSeekerFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,		
+		--Dragon Magazine
+		["ASSASSIN"] = function() return addAssassinFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		--EPG
+		["ARTIFICER"] = function() return addArtificerFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,		
+		--FPG
+		["SWORDMAGE"] = function() return addSwordmageFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		--HoFL
+		["CLERIC (WARPRIEST)"] = function() return addClericWarpriestFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["FIGHTER (KNIGHT)"] = function() return addFighterKnightFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["WIZARD (MAGE)"] = function() return addWizardMageFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		--HotFK
+		["DRUID (SENTINEL)"] = function() return addDruidSentinelFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["PALADIN (CAVALIER)"] = function() return addPaladinCavalierFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["RANGER (HUNTER)"] = function() return addRangerHunterFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["RANGER (SCOUT)"] = function() return addRangerScoutFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["WARLOCK (HEXBLADE)"] = function() return addWarlockHexbladeFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,		
+		--HoS
+		["ASSASSIN (EXECUTIONER)"] = function() return addAssassinExecutionerFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["PALADIN (BLACKGUARD)"] = function() return addPaladinBlackguardFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["WARLOCK (BINDER)"] = function() return addWarlockBinderFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		--HoF
+		["BARBARIAN (BERSERKER)"] = function() return addBarbarianBerserkerFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["DRUID (PROTECTOR)"] = function() return addDruidProtectorFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["WIZARD (WITCH)"] = function() return addWizardWitchFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		--HoEC
+		["SORCERER (ELEMENTALIST)"] = function() return addSorcererElementalistFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		default = function() return addDefaultClassFeature(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription) end
+	});
+end

--- a/scripts/manager_char_class_powers.lua
+++ b/scripts/manager_char_class_powers.lua
@@ -1,54 +1,42 @@
-function addClassSpecificPowers(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription)
-	switch(sClassName:upper(), 
-	{
-		--PHB1
-		["WARLOCK"] = function() return addWarlockPowers(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["WARLORD (MARSHAL)"] = function() return addWarlordMarshalFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["WIZARD (ARCANIST)"] = function() return addWizardArcanistFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		--PHB2
-		["AVENGER"] = function() return addAvengerFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["BARBARIAN"] = function() return addBarbarianFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["BARD"] = function() return addBardFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["DRUID"] = function() return addDruidFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["INVOKER"] = function() return addInvokerFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["SHAMAN"] = function() return addShamanFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["SORCERER"] = function() return addSorcererFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["WARDEN"] = function() return addWardenFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		--PHB3
-		["ARDENT"] = function() return addArdentFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["BATTLEMIND"] = function() return addBattlemindFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["MONK"] = function() return addMonkFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,	
-		["PSION"] = function() return addPsionFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["RUNEPRIEST"] = function() return addRunepriestFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["SEEKER"] = function() return addSeekerFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,		
-		--Dragon Magazine
-		["ASSASSIN"] = function() return addAssassinFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		--EPG
-		["ARTIFICER"] = function() return addArtificerFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,		
-		--FPG
-		["SWORDMAGE"] = function() return addSwordmageFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		--HoFL
-		["CLERIC (WARPRIEST)"] = function() return addClericWarpriestFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["FIGHTER (KNIGHT)"] = function() return addFighterKnightFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["WIZARD (MAGE)"] = function() return addWizardMageFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		--HotFK
-		["DRUID (SENTINEL)"] = function() return addDruidSentinelFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["PALADIN (CAVALIER)"] = function() return addPaladinCavalierFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["RANGER (HUNTER)"] = function() return addRangerHunterFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["RANGER (SCOUT)"] = function() return addRangerScoutFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["WARLOCK (HEXBLADE)"] = function() return addWarlockHexbladeFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,		
-		--HoS
-		["ASSASSIN (EXECUTIONER)"] = function() return addAssassinExecutionerFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["PALADIN (BLACKGUARD)"] = function() return addPaladinBlackguardFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["WARLOCK (BINDER)"] = function() return addWarlockBinderFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		--HoF
-		["BARBARIAN (BERSERKER)"] = function() return addBarbarianBerserkerFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["DRUID (PROTECTOR)"] = function() return addDruidProtectorFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["WIZARD (WITCH)"] = function() return addWizardWitchFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		--HoEC
-		["SORCERER (ELEMENTALIST)"] = function() return addSorcererElementalistFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		default = function() return addDefaultClassFeature(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription) end
-	});
+-- 
+-- Please see the license.html file included with this distribution for 
+-- attribution and copyright information.
+--
+
+function getRecordLinkFromPowerName()
+end
+
+function addPowerFromRecordLink(rAdd, sPowerName, sPowerPath)
+	if not rAdd or not sPowerName or not sPowerPath then
+		ChatManager.SystemMessageResource("char_error_addclassspower");
+		return;
+	end
+	local tCurrentPowers = DB.getChildren(rAdd.nodeChar, "powers");
+	local isPowerInList = false;
+	for _, powerNode in pairs(tCurrentPowers) do
+		if DB.getText(powerNode, "name") == sPowerName then
+			isPowerInList = true;
+			break;
+		end
+	end
+	if isPowerInList == false and DB.findNode(DB.getPath(sPowerPath)) then
+		local sPowerActionSpeed = DB.getText(DB.getPath(sPowerPath, "action"));
+		local sPowerSource = DB.getText(DB.getPath(sPowerPath, "source"));
+		local sPowerKeywords = DB.getText(DB.getPath(sPowerPath, "keywords"));
+		local sPowerRange = DB.getText(DB.getPath(sPowerPath, "range"));
+		local sPowerRecharge = DB.getText(DB.getPath(sPowerPath, "recharge"));
+		local sPowerFullDescription = DB.getText(DB.getPath(sPowerPath, "flavor")) .. "\n\n" .. DB.getText(DB.getPath(sPowerPath, "description"))
+		local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("powers"));
+		DB.setValue(rCreatedIDChildNode, "action", "string", sPowerActionSpeed);
+		DB.setValue(rCreatedIDChildNode, "name", "string", sPowerName);
+		DB.setValue(rCreatedIDChildNode, "source", "string", sPowerSource);
+		DB.setValue(rCreatedIDChildNode, "keywords", "string", sPowerKeywords);
+		DB.setValue(rCreatedIDChildNode, "range", "string", sPowerRange);
+		DB.setValue(rCreatedIDChildNode, "recharge", "string", sPowerRecharge);
+		DB.setValue(rCreatedIDChildNode, "shortdescription", "string", sPowerFullDescription);
+		CharManager.parseDescription(rCreatedIDChildNode);
+		ChatManager.SystemMessageResource("char_abilities_message_poweradd", sPowerName, rAdd.sCharName);
+	end	
 end
 
 ---------------------------------------------
@@ -57,7 +45,7 @@ end
 --Adds all powers that are in the text of a class feature
 function addAllFeaturePowers(rAdd, sClassFeatureOriginalDescription, sClassFeatureName)
 	if not rAdd or not sClassFeatureOriginalDescription or not sClassFeatureName then
-		CharManager.outputUserMessage("char_error_addclassspower");
+		ChatManager.SystemMessageResource("char_error_addclassspower");
 		return;
 	end
 	local sPattern = '<link class="powerdesc" recordname="reference.powers.(%w+)@([%w%s]+)">';
@@ -65,40 +53,14 @@ function addAllFeaturePowers(rAdd, sClassFeatureOriginalDescription, sClassFeatu
 	for w,v in sPowersLink do
 		local sPowerPath = "reference.powers." .. w .. "@" .. v;
 		local sPowerName = DB.getText(DB.getPath(sPowerPath, "name"));
-		
-		local tCurrentPowers = DB.getChildren(rAdd.nodeChar, "powers");
-		local isPowerInList = false;
-		for _, powerNode in pairs(tCurrentPowers) do
-			if DB.getText(powerNode, "name") == sPowerName then
-				isPowerInList = true;
-				break;
-			end
-		end
-		if isPowerInList == false and DB.findNode(DB.getPath(sPowerPath)) then
-			local sPowerActionSpeed = DB.getText(DB.getPath(sPowerPath, "action"));
-			local sPowerSource = DB.getText(DB.getPath(sPowerPath, "source"));
-			local sPowerKeywords = DB.getText(DB.getPath(sPowerPath, "keywords"));
-			local sPowerRange = DB.getText(DB.getPath(sPowerPath, "range"));
-			local sPowerRecharge = DB.getText(DB.getPath(sPowerPath, "recharge"));
-			local sPowerFullDescription = DB.getText(DB.getPath(sPowerPath, "flavor")) .. "\n\n" .. DB.getText(DB.getPath(sPowerPath, "description"))
-			local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("powers"));
-			DB.setValue(rCreatedIDChildNode, "action", "string", sPowerActionSpeed);
-			DB.setValue(rCreatedIDChildNode, "name", "string", sPowerName);
-			DB.setValue(rCreatedIDChildNode, "source", "string", sPowerSource);
-			DB.setValue(rCreatedIDChildNode, "keywords", "string", sPowerKeywords);
-			DB.setValue(rCreatedIDChildNode, "range", "string", sPowerRange);
-			DB.setValue(rCreatedIDChildNode, "recharge", "string", sPowerRecharge);
-			DB.setValue(rCreatedIDChildNode, "shortdescription", "string", sPowerFullDescription);
-			CharManager.parseDescription(rCreatedIDChildNode);
-			ChatManager.SystemMessageResource("char_abilities_message_poweradd", sPowerName, rAdd.sCharName);
-		end
+		addPowerFromRecordLink(rAdd, sPowerName, sPowerPath);
 	end
 end
 
 --Adds a power based that matches the name of a feature
 function addFeatureNamePower(rAdd, sClassFeatureName)
 	if not rAdd or not sClassFeatureName then
-		CharManager.outputUserMessage("char_error_addclassspower");
+		ChatManager.SystemMessageResource("char_error_addclassspower");
 		return;
 	end
 	local tPowerNodes = DB.getChildrenGlobal("reference.powers");
@@ -106,32 +68,7 @@ function addFeatureNamePower(rAdd, sClassFeatureName)
 		local sPowerName = DB.getText(DB.getPath(powerNode, "name"));
 		if sClassFeatureName == sPowerName then
 			local sPowerPath = DB.getPath(powerNode);
-			local tCurrentPowers = DB.getChildren(rAdd.nodeChar, "powers");
-			local isPowerInList = false;
-			for _, currentPower in pairs(tCurrentPowers) do
-				if DB.getText(currentPower, "name") == sPowerName then
-					isPowerInList = true;
-					break;
-				end
-			end
-			if isPowerInList == false and sPowerPath and sPowerPath ~= "" then
-				local sPowerActionSpeed = DB.getText(DB.getPath(sPowerPath, "action"));
-				local sPowerSource = DB.getText(DB.getPath(sPowerPath, "source"));
-				local sPowerKeywords = DB.getText(DB.getPath(sPowerPath, "keywords"));
-				local sPowerRange = DB.getText(DB.getPath(sPowerPath, "range"));
-				local sPowerRecharge = DB.getText(DB.getPath(sPowerPath, "recharge"));
-				local sPowerFullDescription = DB.getText(DB.getPath(sPowerPath, "flavor")) .. "\n\n" .. DB.getText(DB.getPath(sPowerPath, "description"))
-				local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("powers"));
-				DB.setValue(rCreatedIDChildNode, "action", "string", sPowerActionSpeed);
-				DB.setValue(rCreatedIDChildNode, "name", "string", sPowerName);
-				DB.setValue(rCreatedIDChildNode, "source", "string", sPowerSource);
-				DB.setValue(rCreatedIDChildNode, "keywords", "string", sPowerKeywords);
-				DB.setValue(rCreatedIDChildNode, "range", "string", sPowerRange);
-				DB.setValue(rCreatedIDChildNode, "recharge", "string", sPowerRecharge);
-				DB.setValue(rCreatedIDChildNode, "shortdescription", "string", sPowerFullDescription);
-				CharManager.parseDescription(rCreatedIDChildNode);
-				ChatManager.SystemMessageResource("char_abilities_message_poweradd", sPowerName, rAdd.sCharName);
-			end
+			addPowerFromRecordLink(rAdd, sPowerName, sPowerPath);
 			break;
 		end
 	end
@@ -140,7 +77,7 @@ end
 --Searches Sub-Feature Text for Name of all Powers from the parent class feature text, and adds them
 function addAllPowersFromFeatureText(rAdd, sSubClassFeatureOriginalDescription, sParentClassFeatureOriginalDescription)
 	if not rAdd or not sSubClassFeatureOriginalDescription or not sParentClassFeatureOriginalDescription then
-		CharManager.outputUserMessage("char_error_addclassspower");
+		ChatManager.SystemMessageResource("char_error_addclassspower");
 		return;
 	end
 	local sPattern = '<link class="powerdesc" recordname="reference.powers.(%w+)@([%w%s]+)">';
@@ -156,32 +93,7 @@ function addAllPowersFromFeatureText(rAdd, sSubClassFeatureOriginalDescription, 
 	end
 	--Add all the powers that were found in the Sub-Feature
 	for powerName,powerPath in pairs(tPowersInFeature) do
-		local tCurrentPowers = DB.getChildren(rAdd.nodeChar, "powers");
-		local isPowerInList = false;
-		for _, powerNode in pairs(tCurrentPowers) do
-			if DB.getText(DB.getPath(powerNode, "name")) == powerName then
-				isPowerInList = true;
-				break;
-			end
-		end
-		if isPowerInList == false and DB.findNode(DB.getPath(powerPath)) then
-			local sPowerActionSpeed = DB.getText(DB.getPath(powerPath, "action"));
-			local sPowerSource = DB.getText(DB.getPath(powerPath, "source"));
-			local sPowerKeywords = DB.getText(DB.getPath(powerPath, "keywords"));
-			local sPowerRange = DB.getText(DB.getPath(powerPath, "range"));
-			local sPowerRecharge = DB.getText(DB.getPath(powerPath, "recharge"));
-			local sPowerFullDescription = DB.getText(DB.getPath(powerPath, "flavor")) .. "\n\n" .. DB.getText(DB.getPath(powerPath, "description"))
-			local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("powers"));
-			DB.setValue(rCreatedIDChildNode, "action", "string", sPowerActionSpeed);
-			DB.setValue(rCreatedIDChildNode, "name", "string", powerName);
-			DB.setValue(rCreatedIDChildNode, "source", "string", sPowerSource);
-			DB.setValue(rCreatedIDChildNode, "keywords", "string", sPowerKeywords);
-			DB.setValue(rCreatedIDChildNode, "range", "string", sPowerRange);
-			DB.setValue(rCreatedIDChildNode, "recharge", "string", sPowerRecharge);
-			DB.setValue(rCreatedIDChildNode, "shortdescription", "string", sPowerFullDescription);
-			CharManager.parseDescription(rCreatedIDChildNode);
-			ChatManager.SystemMessageResource("char_abilities_message_poweradd", powerName, rAdd.sCharName);
-		end
+		addPowerFromRecordLink(rAdd, powerName, powerPath);
 	end
 end
 
@@ -194,13 +106,11 @@ function displayClassPowerSelectionsDialog(rAdd, sClassFeatureOriginalDescriptio
 	--Display information on the selections in chat
 	local sPattern = '<link class="powerdesc" recordname="reference.powers.(%w+)@([%w%s]+)">';
 	local sPowersLink = string.gmatch(sClassFeatureOriginalDescription, sPattern);
-	local nOptionsCount = 1;
 	for w,v in sPowersLink do
 		local sPattern = "reference.powers." .. w .. "@" .. v;
 		local sClassFeatureName = DB.getText(DB.getPath(sPattern, "name"));
 		local sClassFeatureDescription = DB.getText(DB.getPath(sPattern, "description"));
 		table.insert(tOptions, { text = sClassFeatureName, linkclass = "powerdesc", linkrecord = DB.getPath(sPattern), });
-		nOptionsCount = nOptionsCount + 1;
 	end
 	--Display a pop-up where we choose from the class power options
 	if not nMaxSelections or nMaxSelections < 1 then
@@ -213,18 +123,158 @@ function displayClassPowerSelectionsDialog(rAdd, sClassFeatureOriginalDescriptio
 		options = tOptions,
 		min = nMaxSelections,
 		max = nMaxSelections,
-		callback = CharClassFeatureManager.callbackResolveClassFeatureSelectionsDialogSelection,
+		callback = CharClassPowerManager.callbackResolveClassPowersSelectionsDialogSelection,
 		custom = rAdd, 
 	};
 	DialogManager.requestSelectionDialog(tDialogData);	
 end
 function callbackResolveClassPowersSelectionsDialogSelection(tSelection, rAdd, tSelectionLinks)
 	if not tSelection or not tSelection[1] then
-		CharManager.outputUserMessage("char_error_addclassspower");
+		ChatManager.SystemMessageResource("char_error_addclassspower");
 		return;
 	end
 	if not tSelectionLinks then
-		CharManager.outputUserMessage("char_error_addclassspower");
+		ChatManager.SystemMessageResource("char_error_addclassspower");
+		return;
+	end
+	for i, selectedPower in ipairs(tSelectionLinks) do
+		local sPowerPath = selectedPower.linkrecord;
+		local sPowerName = tSelection[i];
+		addPowerFromRecordLink(rAdd, sPowerName, sPowerPath);
+	end
+end
+
+function dispayItalicPowersDialog(rAdd, sClassFeatureOriginalDescription, sClassFeatureName, nMaxSelections)
+	if not rAdd or not sClassFeatureOriginalDescription then
+		ChatManager.SystemMessageResource("char_error_addclassspower");
+		return;
+	end
+	local tOptions = {};
+	local tTotalPowerNames = {};
+	local nTotalPowerCount = 1;
+	--Get all the italicized powers first
+	local sPattern = "<i>(.-)</i>";
+	local fItalicizedSections = string.gmatch(sClassFeatureOriginalDescription, sPattern);
+	for italicsPowerName in fItalicizedSections do
+		if not string.find(italicsPowerName, ",") then
+			if italicsPowerName and StringManager.trim(italicsPowerName) ~= "" then
+				tTotalPowerNames[nTotalPowerCount] = StringManager.trim(italicsPowerName);
+				nTotalPowerCount = nTotalPowerCount + 1;
+			end
+		else
+			local tItalicsPowerSplit = StringManager.splitByPattern(italicsPowerName, ",", true);
+			for key,x in pairs(tItalicsPowerSplit) do
+				if x and StringManager.trim(x) ~= "" then
+					tTotalPowerNames[nTotalPowerCount] = StringManager.trim(x);
+					nTotalPowerCount = nTotalPowerCount + 1;
+				end
+			end
+		end
+	end
+
+	--Check the number of selections
+	local sChoiceNumberMatch = string.match(sClassFeatureOriginalDescription, "gain ([%w'-]+).*%sof your choice%s*:");
+	if sChoiceNumberMatch then
+		nMaxSelections = convertWordToNumber(sChoiceNumberMatch);
+	end
+	if not nMaxSelections or nMaxSelections < 1 then
+		nMaxSelections = 1;
+	end
+
+	--Decide whether we get all of them or choose
+	local bIsOrConjunction = false;
+	if string.find(sClassFeatureOriginalDescription, "[%s>]or[%s<]") then
+		bIsOrConjunction = true;
+	end
+
+	if bIsOrConjunction then
+		local tGlobalPowerNodes = DB.getChildrenGlobal("reference.powers");
+		for i, italicsPowerName in ipairs(tTotalPowerNames) do
+			for _,powerNode in ipairs(tGlobalPowerNodes) do
+				local sPowerName = DB.getText(DB.getPath(powerNode, "name"));
+				if italicsPowerName:lower() == sPowerName:lower() then
+					local sPowerPath = DB.getPath(powerNode);
+					table.insert(tOptions, { text = sPowerName, linkclass = "powerdesc", linkrecord = sPowerPath, });
+				end
+			end
+		end
+
+		--Display a pop-up where we choose from the class power options
+		local msg = string.format(Interface.getString("char_build_message_chooseclasspowers"), nMaxSelections, sClassFeatureName);
+		local tDialogData = {
+			title = sClassFeatureName,
+			msg = msg,
+			options = tOptions,
+			min = nMaxSelections,
+			max = nMaxSelections,
+			callback = CharClassPowerManager.callbackResolveClassPowersSelectionsDialogSelection,
+			custom = rAdd, 
+		};
+		DialogManager.requestSelectionDialog(tDialogData);
+	end
+end
+
+
+-------------------------------------------
+----- WIZARD (ARCANIST) Class Features ----
+-------------------------------------------
+function addWizardArcanistSpellbookPowers(rAdd, sClassName, nNumberOfPowers)
+	local sDailyAttackText = "Daily";
+	local sAttackTypeText = "Attack";
+	local sUtilityTypeText = "Utility";
+	local sRefreshText = sDailyAttackText;
+
+	local tPowersforLevelAndClass = {};
+	local tPowers = {};
+	local nPowersCount = 1;
+	local nOptionsCount = 1;
+	--Use version of class name without the parentheses
+	local sFilteredClassName = StringManager.trim(string.gsub(sClassName, "%b()", ""));
+	local tPowerNodes = DB.getChildrenGlobal("reference.powers");
+	for _,powerNode in ipairs(tPowerNodes) do
+		local sPowerClass = Classes4eExtensionLibraryData.getClassOrRaceValue(powerNode);
+		local sPowerLevel = Classes4eExtensionLibraryData.getPowerLevelValue(powerNode);
+		local sPowerRecharge = Classes4eExtensionLibraryData.getRechargeValue(powerNode);
+		if sPowerClass == sFilteredClassName and sPowerLevel == "1" then
+			tPowersforLevelAndClass[nOptionsCount] = powerNode;
+			nOptionsCount = nOptionsCount + 1;
+			if sPowerRecharge == sRefreshText then
+				tPowers[nPowersCount] = powerNode;
+				nPowersCount = nPowersCount + 1;
+			end
+		end
+	end
+
+	displayWizardArcanistSpellbookDailyAttackDialog(rAdd, sClassName, tPowers, nNumberOfPowers, sRefreshText);
+end
+function displayWizardArcanistSpellbookDailyAttackDialog(rAdd, sClassName, tPowers, nNumberOfPowers, sRefreshText)
+	local tOptions = {};
+	for _,y in ipairs(tPowers) do
+		local sClassFeatureName = DB.getText(DB.getPath(y, "name"));
+		local sClassFeatureDescription = DB.getText(DB.getPath(y, "description"));
+		table.insert(tOptions, { text = sClassFeatureName, linkclass = "powerdesc", linkrecord = DB.getPath(y), });
+	end
+	if not nNumberOfPowers then
+		nNumberOfPowers = 2;
+	end
+	local tDialogData = {
+		title = "Wizard Spellbook",
+		msg = "Choose 2 Daily Attack powers.",
+		options = tOptions,
+		min = nNumberOfPowers,
+		max = nNumberOfPowers,
+		callback = CharClassPowerManager.callbackResolveSpellbookPowerDialogSelection,
+		custom = rAdd, 
+	};
+	DialogManager.requestSelectionDialog(tDialogData);
+end
+function callbackResolveSpellbookPowerDialogSelection(tSelection, rAdd, tSelectionLinks)
+	if not tSelection or not tSelection[1] then
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
+		return;
+	end
+	if not tSelectionLinks then
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
 		return;
 	end
 	for i, selectedPower in ipairs(tSelectionLinks) do
@@ -258,5 +308,103 @@ function callbackResolveClassPowersSelectionsDialogSelection(tSelection, rAdd, t
 			ChatManager.SystemMessageResource("char_abilities_message_poweradd", sPowerName, rAdd.sCharName);
 		end
 	end
+	displayWizardArcanistSpellbookPreparationDialog(rAdd, tSelectionLinks);
+end
+function displayWizardArcanistSpellbookPreparationDialog(rAdd, tPowerLinks)
+	local tOptions = {};
+	for _,y in ipairs(tPowerLinks) do
+		local sPowerPath = y.linkrecord;
+		local sClassFeatureName = DB.getText(DB.getPath(sPowerPath, "name"));
+		local sClassFeatureDescription = DB.getText(DB.getPath(sPowerPath, "description"));
+		table.insert(tOptions, { text = sClassFeatureName, linkclass = "powerdesc", linkrecord = DB.getPath(sPowerPath), });
+	end
+	local tDialogData = {
+		title = "Wizard Spellbook",
+		msg = "Choose 1 of these spells to prepare.",
+		options = tOptions,
+		min = 1,
+		max = 1,
+		callback = CharClassPowerManager.callbackResolveSpellbookPreparationDialogSelection,
+		custom = { rAdd=rAdd, tTotalOptions=tOptions }, 
+	};
+	DialogManager.requestSelectionDialog(tDialogData);
+end
+function callbackResolveSpellbookPreparationDialogSelection(tSelection, tData, tSelectionLinks)
+	if not tSelection or not tSelection[1] then
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
+		return;
+	end
+	if not tSelectionLinks then
+		ChatManager.SystemMessageResource("char_error_addclasssfeature");
+		return;
+	end
+	--Set the selected power to prepared
+	-- for i, selectedPower in ipairs(tSelectionLinks) do
+	-- 	local sPowerPath = selectedPower.linkrecord;
+	-- 	local sPowerName = tSelection[i];
+	-- 	Debug.console("Preparing sPowerName", sPowerName);
+
+	-- 	local tCurrentPowers = DB.getChildren(tData.rAdd.nodeChar, "powers");
+	-- 	local isPowerInList = false;
+	-- 	for _, powerNode in pairs(tCurrentPowers) do
+	-- 		if DB.getText(powerNode, "name") == sPowerName then
+	-- 			isPowerInList = true;
+	-- 			break;
+	-- 		end
+	-- 	end
+	-- 	if isPowerInList == true then
+	-- 		local rChildNode = DB.getChild(tData.rAdd.nodeChar.getPath("powers"), "name");
+	-- 		DB.setValue(rChildNode, "prepared", "number", 1);
+	-- 		ChatManager.SystemMessageResource("char_abilities_message_poweradd", sPowerName, tData.rAdd.sCharName);
+	-- 	end
+	-- end
+	--Set every other power not selected to not prepared
+	for i, allPowers in ipairs(tData.tTotalOptions) do
+		local sAllPowerName = allPowers.text;
+		Debug.console("all Powers", sAllPowerName);
+		local isASelectedPower = false;
+		for x,selectedPower in ipairs(tSelectionLinks) do
+			local sSelectedPowerName = tSelection[x];
+			Debug.console("Checking against ", sSelectedPowerName);
+			if sSelectedPowerName == sAllPowerName then
+				isASelectedPower = true;
+				Debug.console("isASelectedPower", isASelectedPower);
+			end
+		end
+		local tCurrentPowers = DB.getChildren(tData.rAdd.nodeChar, "powers");
+		Debug.console("tCurrentPowers", tCurrentPowers);
+		for _,existingPowerNode in pairs(tCurrentPowers) do
+			Debug.console("Existing power named", DB.getText(existingPowerNode, "name"));
+			if DB.getText(existingPowerNode, "name") == sAllPowerName then
+				Debug.console("Found power");
+				if isASelectedPower then
+					DB.setValue(existingPowerNode, "prepared", "number", 1);
+				else
+					DB.setValue(existingPowerNode, "prepared", "number", 0);
+				end
+			end
+		end
+	end
+end 
+
+function addSpellbookToInventory(rAdd)
 end
 
+
+---------------------------------------
+-- Utility functions
+---------------------------------------
+function convertWordToNumber(word)
+	local numberWords = {
+	    ["zero"] = 0,
+	    ["one"] = 1,
+	    ["two"] = 2,
+	    ["three"] = 3,
+	    ["four"] = 4,
+	    ["five"] = 5,
+	    ["six"] = 6,
+	};
+
+    local lowerCaseWord = string.lower(word)
+    return numberWords[lowerCaseWord]
+end

--- a/scripts/manager_char_class_powers.lua
+++ b/scripts/manager_char_class_powers.lua
@@ -2,11 +2,7 @@ function addClassSpecificPowers(sClassName, rAdd, sClassFeatureName, sClassFeatu
 	switch(sClassName:upper(), 
 	{
 		--PHB1
-		["CLERIC (TEMPLAR)"] = function() return addClericTemplarFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["FIGHTER (WEAPONMASTER)"] = function() return addFighterWeaponmasterFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["RANGER"] = function() return addRangerFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["ROGUE (SCOUNDREL)"] = function() return addRogueScoundrelFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
-		["WARLOCK"] = function() return addWarlockFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
+		["WARLOCK"] = function() return addWarlockPowers(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
 		["WARLORD (MARSHAL)"] = function() return addWarlordMarshalFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
 		["WIZARD (ARCANIST)"] = function() return addWizardArcanistFeatures(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription, sClassFeatureOriginalDescription) end,
 		--PHB2
@@ -54,3 +50,213 @@ function addClassSpecificPowers(sClassName, rAdd, sClassFeatureName, sClassFeatu
 		default = function() return addDefaultClassFeature(sClassName, rAdd, sClassFeatureName, sClassFeatureFilteredDescription) end
 	});
 end
+
+---------------------------------------------
+--- Generic Non-Dialogue Power Add Methods
+---------------------------------------------
+--Adds all powers that are in the text of a class feature
+function addAllFeaturePowers(rAdd, sClassFeatureOriginalDescription, sClassFeatureName)
+	if not rAdd or not sClassFeatureOriginalDescription or not sClassFeatureName then
+		CharManager.outputUserMessage("char_error_addclassspower");
+		return;
+	end
+	local sPattern = '<link class="powerdesc" recordname="reference.powers.(%w+)@([%w%s]+)">';
+	local sPowersLink = string.gmatch(sClassFeatureOriginalDescription, sPattern);
+	for w,v in sPowersLink do
+		local sPowerPath = "reference.powers." .. w .. "@" .. v;
+		local sPowerName = DB.getText(DB.getPath(sPowerPath, "name"));
+		
+		local tCurrentPowers = DB.getChildren(rAdd.nodeChar, "powers");
+		local isPowerInList = false;
+		for _, powerNode in pairs(tCurrentPowers) do
+			if DB.getText(powerNode, "name") == sPowerName then
+				isPowerInList = true;
+				break;
+			end
+		end
+		if isPowerInList == false and DB.findNode(DB.getPath(sPowerPath)) then
+			local sPowerActionSpeed = DB.getText(DB.getPath(sPowerPath, "action"));
+			local sPowerSource = DB.getText(DB.getPath(sPowerPath, "source"));
+			local sPowerKeywords = DB.getText(DB.getPath(sPowerPath, "keywords"));
+			local sPowerRange = DB.getText(DB.getPath(sPowerPath, "range"));
+			local sPowerRecharge = DB.getText(DB.getPath(sPowerPath, "recharge"));
+			local sPowerFullDescription = DB.getText(DB.getPath(sPowerPath, "flavor")) .. "\n\n" .. DB.getText(DB.getPath(sPowerPath, "description"))
+			local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("powers"));
+			DB.setValue(rCreatedIDChildNode, "action", "string", sPowerActionSpeed);
+			DB.setValue(rCreatedIDChildNode, "name", "string", sPowerName);
+			DB.setValue(rCreatedIDChildNode, "source", "string", sPowerSource);
+			DB.setValue(rCreatedIDChildNode, "keywords", "string", sPowerKeywords);
+			DB.setValue(rCreatedIDChildNode, "range", "string", sPowerRange);
+			DB.setValue(rCreatedIDChildNode, "recharge", "string", sPowerRecharge);
+			DB.setValue(rCreatedIDChildNode, "shortdescription", "string", sPowerFullDescription);
+			CharManager.parseDescription(rCreatedIDChildNode);
+			ChatManager.SystemMessageResource("char_abilities_message_poweradd", sPowerName, rAdd.sCharName);
+		end
+	end
+end
+
+--Adds a power based that matches the name of a feature
+function addFeatureNamePower(rAdd, sClassFeatureName)
+	if not rAdd or not sClassFeatureName then
+		CharManager.outputUserMessage("char_error_addclassspower");
+		return;
+	end
+	local tPowerNodes = DB.getChildrenGlobal("reference.powers");
+	for _,powerNode in ipairs(tPowerNodes) do
+		local sPowerName = DB.getText(DB.getPath(powerNode, "name"));
+		if sClassFeatureName == sPowerName then
+			local sPowerPath = DB.getPath(powerNode);
+			local tCurrentPowers = DB.getChildren(rAdd.nodeChar, "powers");
+			local isPowerInList = false;
+			for _, currentPower in pairs(tCurrentPowers) do
+				if DB.getText(currentPower, "name") == sPowerName then
+					isPowerInList = true;
+					break;
+				end
+			end
+			if isPowerInList == false and sPowerPath and sPowerPath ~= "" then
+				local sPowerActionSpeed = DB.getText(DB.getPath(sPowerPath, "action"));
+				local sPowerSource = DB.getText(DB.getPath(sPowerPath, "source"));
+				local sPowerKeywords = DB.getText(DB.getPath(sPowerPath, "keywords"));
+				local sPowerRange = DB.getText(DB.getPath(sPowerPath, "range"));
+				local sPowerRecharge = DB.getText(DB.getPath(sPowerPath, "recharge"));
+				local sPowerFullDescription = DB.getText(DB.getPath(sPowerPath, "flavor")) .. "\n\n" .. DB.getText(DB.getPath(sPowerPath, "description"))
+				local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("powers"));
+				DB.setValue(rCreatedIDChildNode, "action", "string", sPowerActionSpeed);
+				DB.setValue(rCreatedIDChildNode, "name", "string", sPowerName);
+				DB.setValue(rCreatedIDChildNode, "source", "string", sPowerSource);
+				DB.setValue(rCreatedIDChildNode, "keywords", "string", sPowerKeywords);
+				DB.setValue(rCreatedIDChildNode, "range", "string", sPowerRange);
+				DB.setValue(rCreatedIDChildNode, "recharge", "string", sPowerRecharge);
+				DB.setValue(rCreatedIDChildNode, "shortdescription", "string", sPowerFullDescription);
+				CharManager.parseDescription(rCreatedIDChildNode);
+				ChatManager.SystemMessageResource("char_abilities_message_poweradd", sPowerName, rAdd.sCharName);
+			end
+			break;
+		end
+	end
+end
+
+--Searches Sub-Feature Text for Name of all Powers from the parent class feature text, and adds them
+function addAllPowersFromFeatureText(rAdd, sSubClassFeatureOriginalDescription, sParentClassFeatureOriginalDescription)
+	if not rAdd or not sSubClassFeatureOriginalDescription or not sParentClassFeatureOriginalDescription then
+		CharManager.outputUserMessage("char_error_addclassspower");
+		return;
+	end
+	local sPattern = '<link class="powerdesc" recordname="reference.powers.(%w+)@([%w%s]+)">';
+	local sPowersLink = string.gmatch(sParentClassFeatureOriginalDescription, sPattern);
+	local tPowersInFeature = {};
+	for w,v in sPowersLink do
+		local sPowerPath = "reference.powers." .. w .. "@" .. v;
+		local sPowerName = DB.getText(DB.getPath(sPowerPath, "name"));
+		--Is power name in Sub-Feature, add it to table
+		if sPowerName and string.find(sSubClassFeatureOriginalDescription:lower(), sPowerName:lower()) then
+			tPowersInFeature[sPowerName] = sPowerPath;
+		end
+	end
+	--Add all the powers that were found in the Sub-Feature
+	for powerName,powerPath in pairs(tPowersInFeature) do
+		local tCurrentPowers = DB.getChildren(rAdd.nodeChar, "powers");
+		local isPowerInList = false;
+		for _, powerNode in pairs(tCurrentPowers) do
+			if DB.getText(DB.getPath(powerNode, "name")) == powerName then
+				isPowerInList = true;
+				break;
+			end
+		end
+		if isPowerInList == false and DB.findNode(DB.getPath(powerPath)) then
+			local sPowerActionSpeed = DB.getText(DB.getPath(powerPath, "action"));
+			local sPowerSource = DB.getText(DB.getPath(powerPath, "source"));
+			local sPowerKeywords = DB.getText(DB.getPath(powerPath, "keywords"));
+			local sPowerRange = DB.getText(DB.getPath(powerPath, "range"));
+			local sPowerRecharge = DB.getText(DB.getPath(powerPath, "recharge"));
+			local sPowerFullDescription = DB.getText(DB.getPath(powerPath, "flavor")) .. "\n\n" .. DB.getText(DB.getPath(powerPath, "description"))
+			local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("powers"));
+			DB.setValue(rCreatedIDChildNode, "action", "string", sPowerActionSpeed);
+			DB.setValue(rCreatedIDChildNode, "name", "string", powerName);
+			DB.setValue(rCreatedIDChildNode, "source", "string", sPowerSource);
+			DB.setValue(rCreatedIDChildNode, "keywords", "string", sPowerKeywords);
+			DB.setValue(rCreatedIDChildNode, "range", "string", sPowerRange);
+			DB.setValue(rCreatedIDChildNode, "recharge", "string", sPowerRecharge);
+			DB.setValue(rCreatedIDChildNode, "shortdescription", "string", sPowerFullDescription);
+			CharManager.parseDescription(rCreatedIDChildNode);
+			ChatManager.SystemMessageResource("char_abilities_message_poweradd", powerName, rAdd.sCharName);
+		end
+	end
+end
+
+---------------------------------------------
+--- Generic Dialogue Selection Methods
+---------------------------------------------
+
+function displayClassPowerSelectionsDialog(rAdd, sClassFeatureOriginalDescription, sClassFeatureName, nMaxSelections)
+	local tOptions = {};
+	--Display information on the selections in chat
+	local sPattern = '<link class="powerdesc" recordname="reference.powers.(%w+)@([%w%s]+)">';
+	local sPowersLink = string.gmatch(sClassFeatureOriginalDescription, sPattern);
+	local nOptionsCount = 1;
+	for w,v in sPowersLink do
+		local sPattern = "reference.powers." .. w .. "@" .. v;
+		local sClassFeatureName = DB.getText(DB.getPath(sPattern, "name"));
+		local sClassFeatureDescription = DB.getText(DB.getPath(sPattern, "description"));
+		table.insert(tOptions, { text = sClassFeatureName, linkclass = "powerdesc", linkrecord = DB.getPath(sPattern), });
+		nOptionsCount = nOptionsCount + 1;
+	end
+	--Display a pop-up where we choose from the class power options
+	if not nMaxSelections or nMaxSelections < 1 then
+		nMaxSelections = 1;
+	end
+	local msg = string.format(Interface.getString("char_build_message_chooseclasspowers"), nMaxSelections, sClassFeatureName);
+	local tDialogData = {
+		title = sClassFeatureName,
+		msg = msg,
+		options = tOptions,
+		min = nMaxSelections,
+		max = nMaxSelections,
+		callback = CharClassFeatureManager.callbackResolveClassFeatureSelectionsDialogSelection,
+		custom = rAdd, 
+	};
+	DialogManager.requestSelectionDialog(tDialogData);	
+end
+function callbackResolveClassPowersSelectionsDialogSelection(tSelection, rAdd, tSelectionLinks)
+	if not tSelection or not tSelection[1] then
+		CharManager.outputUserMessage("char_error_addclassspower");
+		return;
+	end
+	if not tSelectionLinks then
+		CharManager.outputUserMessage("char_error_addclassspower");
+		return;
+	end
+	for i, selectedPower in ipairs(tSelectionLinks) do
+		local sPowerPath = selectedPower.linkrecord;
+		local sPowerName = tSelection[i];
+
+		local tCurrentPowers = DB.getChildren(rAdd.nodeChar, "powers");
+		local isPowerInList = false;
+		for _, powerNode in pairs(tCurrentPowers) do
+			if DB.getText(powerNode, "name") == sPowerName then
+				isPowerInList = true;
+				break;
+			end
+		end
+		if isPowerInList == false then
+			local sPowerActionSpeed = DB.getText(DB.getPath(sPowerPath, "action"));
+			local sPowerSource = DB.getText(DB.getPath(sPowerPath, "source"));
+			local sPowerKeywords = DB.getText(DB.getPath(sPowerPath, "keywords"));
+			local sPowerRange = DB.getText(DB.getPath(sPowerPath, "range"));
+			local sPowerRecharge = DB.getText(DB.getPath(sPowerPath, "recharge"));
+			local sPowerFullDescription = DB.getText(DB.getPath(sPowerPath, "flavor")) .. "\n\n" .. DB.getText(DB.getPath(sPowerPath, "description"))
+			local rCreatedIDChildNode = DB.createChild(rAdd.nodeChar.getPath("powers"));
+			DB.setValue(rCreatedIDChildNode, "action", "string", sPowerActionSpeed);
+			DB.setValue(rCreatedIDChildNode, "name", "string", sPowerName);
+			DB.setValue(rCreatedIDChildNode, "source", "string", sPowerSource);
+			DB.setValue(rCreatedIDChildNode, "keywords", "string", sPowerKeywords);
+			DB.setValue(rCreatedIDChildNode, "range", "string", sPowerRange);
+			DB.setValue(rCreatedIDChildNode, "recharge", "string", sPowerRecharge);
+			DB.setValue(rCreatedIDChildNode, "shortdescription", "string", sPowerFullDescription);
+			CharManager.parseDescription(rCreatedIDChildNode);
+			ChatManager.SystemMessageResource("char_abilities_message_poweradd", sPowerName, rAdd.sCharName);
+		end
+	end
+end
+

--- a/strings/strings_4E_char_build.xml
+++ b/strings/strings_4E_char_build.xml
@@ -9,6 +9,7 @@
   <!-- Character - Build -->
   <string name="char_abilities_message_classadd">Class '%s' added to '%s'.</string>
   <string name="char_abilities_message_classfeatureadd">Class Feature '%s' added to '%s' special ability list.</string>
+  <string name="char_abilities_message_poweradd">'%s' power added to '%s' power list.</string>  
   <string name="char_abilities_message_classfeaturedialoguetitle">Choose a Class Feature</string>
   <string name="char_abilities_message_classfeaturedialoguemsg">Choose one.</string>
   <string name="char_abilities_message_classpoweradd">Class Power '%s' added to '%s' powers list.</string>
@@ -27,6 +28,9 @@
   <string name="char_error_addclasssfeature">Error adding class feature.</string> 
 
   <string name="char_build_message_chooseclassfeatures">Choose %s of the following %s:</string> 
+  <string name="char_error_addclassspower">Error adding class power.</string> 
+
+  <string name="char_build_message_chooseclasspowers">Choose %s of the following %s:</string>   
   <!-- Cleric Feature Strings -->
   <string name="char_build_title_addhealerlore">Healer's Lore or Alternate</string> 
   <string name="char_build_message_addhealerorbattlelore">Choose Healer's Lore or Battle Cleric's Lore. </string>


### PR DESCRIPTION
When dragging a class to a character sheet, it now adds class powers for each feature. For AEDU classes, it also lets you add the normal level 1 2 at-will powers, 1 encounter, and 1 daily. Added support for class powers for PHB1 and PHB2 classes, including adding support for Wizard (Arcanist) spellbook at level 1.

Closing Issues for PHB1 Class class Powers
Closes #47 
Closes #48 
Closes #93
Closes #49 
Closes #50 
Closes #51 
Closes #52 
Closes #53 

Closing Issues for PHB2 Class class Powers
Closes #54 
Closes #55 
Closes #56 
Closes #57 
Closes #58 
Closes #59 
Closes #60 
Closes #61 